### PR TITLE
#161407876 admins can delete reported articles

### DIFF
--- a/server/controllers/articleController.js
+++ b/server/controllers/articleController.js
@@ -265,4 +265,28 @@ export default class ArticleController {
       }
     });
   }
+
+  /**
+   * @description -This method deletes reported article by the admins
+   * @param {object} req - The request payload sent from the router
+   * @param {object} res - The response payload sent back from the controller
+   * @returns {object} - status and message
+   */
+  static deleteReportedArticle(req, res) {
+    Article.findOne({
+      where: { slug: req.params.slug },
+    }).then((article) => {
+      if (!article) {
+        res.status(404).json({ message: 'article does not exist', success: false });
+      } else {
+        article.setTags([]).then(() => {
+          article.destroy()
+            .then(() => {
+              res.status(204).end();
+            })
+            .catch(error => res.status(500).json(error));
+        });
+      }
+    });
+  }
 }

--- a/server/routes/api/admin.js
+++ b/server/routes/api/admin.js
@@ -3,11 +3,13 @@ import AdminController from '../../controllers/adminController';
 import RoleValidation from '../../middlewares/roleValidation';
 import Authenticator from '../../middlewares/authenticator';
 import permit from '../../middlewares/permission';
+import ArticleController from '../../controllers/articleController';
 
 const { checkToken } = Authenticator;
 
 const router = express.Router();
 
 router.post('/admins/role', checkToken, permit('Admin'), RoleValidation.setRole, AdminController.changeRole);
+router.delete('/admins/articles/:slug/reports', checkToken, permit('Admin'), ArticleController.deleteReportedArticle);
 
 export default router;

--- a/server/tests/report.test.js
+++ b/server/tests/report.test.js
@@ -4,16 +4,11 @@ import app from '../index';
 
 chai.use(chaiHttp);
 
-let token = '';
+let userToken;
+let adminToken;
+let authorToken;
 let articleSlug = '';
 let reportId = null;
-
-const user = {
-  username: 'dimeji199',
-  email: 'dimeji019@ola.com',
-  password: 'password009'
-};
-
 
 const article = {
   title: 'How to use the faker package',
@@ -37,11 +32,30 @@ const editReport = {
 describe('Report', () => {
   before((done) => {
     chai.request(app)
-      .post('/api/v1/signup')
-      .send(user)
+      .post('/api/v1/login')
+      .send({ emailOrUsername: 'jane@something.com', password: 'password' })
       .end((err, res) => {
-        const { token: validToken } = res.body;
-        token = validToken;
+        userToken = res.body.token;
+        done();
+      });
+  });
+
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/login')
+      .send({ emailOrUsername: 'jack@something.com', password: 'password' })
+      .end((err, res) => {
+        authorToken = res.body.token;
+        done();
+      });
+  });
+
+  before((done) => {
+    chai.request(app)
+      .post('/api/v1/login')
+      .send({ emailOrUsername: 'jackson@something.com', password: 'password' })
+      .end((err, res) => {
+        adminToken = res.body.token;
         done();
       });
   });
@@ -49,7 +63,7 @@ describe('Report', () => {
   it('Should create an article', (done) => {
     chai.request(app)
       .post('/api/v1/articles')
-      .set('x-access-token', token)
+      .set('x-access-token', authorToken)
       .send(article)
       .end((err, res) => {
         articleSlug = res.body.article.slug;
@@ -66,7 +80,7 @@ describe('Report', () => {
   it('Should create a report', (done) => {
     chai.request(app)
       .post(`/api/v1/articles/${articleSlug}/reports`)
-      .set('x-access-token', token)
+      .set('x-access-token', userToken)
       .send(report)
       .end((err, res) => {
         reportId = res.body.report.id;
@@ -82,7 +96,7 @@ describe('Report', () => {
   it('Should not create a report', (done) => {
     chai.request(app)
       .post('/api/v1/articles/slug-title-123/reports')
-      .set('x-access-token', token)
+      .set('x-access-token', userToken)
       .send({})
       .end((err, res) => {
         expect(res.status).to.equal(422);
@@ -96,7 +110,7 @@ describe('Report', () => {
   it('Should edit a report', (done) => {
     chai.request(app)
       .put(`/api/v1/articles/${articleSlug}/reports/${reportId}/edit`)
-      .set('x-access-token', token)
+      .set('x-access-token', userToken)
       .send(editReport)
       .end((err, res) => {
         expect(res.status).to.equal(200);
@@ -111,7 +125,7 @@ describe('Report', () => {
   it('Should approve a report', (done) => {
     chai.request(app)
       .put(`/api/v1/articles/${articleSlug}/reports/${reportId}/approve`)
-      .set('x-access-token', token)
+      .set('x-access-token', adminToken)
       .send(report)
       .end((err, res) => {
         expect(res.status).to.equal(200);
@@ -126,7 +140,7 @@ describe('Report', () => {
   it('Should get all approve report for an article', (done) => {
     chai.request(app)
       .get(`/api/v1/articles/${articleSlug}/reports/approve`)
-      .set('x-access-token', token)
+      .set('x-access-token', adminToken)
       .send(report)
       .end((err, res) => {
         expect(res.status).to.equal(200);
@@ -141,7 +155,7 @@ describe('Report', () => {
   it('Should get all disapprove report for an article', (done) => {
     chai.request(app)
       .get(`/api/v1/articles/${articleSlug}/reports/disapprove`)
-      .set('x-access-token', token)
+      .set('x-access-token', adminToken)
       .send(report)
       .end((err, res) => {
         expect(res.status).to.equal(200);
@@ -156,7 +170,7 @@ describe('Report', () => {
   it('Should get all disapprove report for an article', (done) => {
     chai.request(app)
       .get(`/api/v1/articles/${articleSlug}/reports/disapprove`)
-      .set('x-access-token', token)
+      .set('x-access-token', adminToken)
       .send(report)
       .end((err, res) => {
         expect(res.status).to.equal(200);
@@ -171,7 +185,7 @@ describe('Report', () => {
   it('Should get all approve report', (done) => {
     chai.request(app)
       .get('/api/v1/reports/approve')
-      .set('x-access-token', token)
+      .set('x-access-token', adminToken)
       .send(report)
       .end((err, res) => {
         expect(res.status).to.equal(200);
@@ -186,7 +200,7 @@ describe('Report', () => {
   it('Should get all disapprove report', (done) => {
     chai.request(app)
       .get('/api/v1/reports/disapprove')
-      .set('x-access-token', token)
+      .set('x-access-token', adminToken)
       .send(report)
       .end((err, res) => {
         expect(res.status).to.equal(200);
@@ -194,6 +208,57 @@ describe('Report', () => {
         expect(res.body).to.be.have.property('success');
         expect(res.body).to.be.have.property('message');
         expect(res.body).to.be.have.property('reports');
+        done();
+      });
+  });
+
+  it('Should not be able to delete reported article if role is User', (done) => {
+    chai.request(app)
+      .delete(`/api/v1/admins/articles/${articleSlug}/reports`)
+      .set('x-access-token', userToken)
+      .send(report)
+      .end((err, res) => {
+        expect(res.status).to.equal(403);
+        expect(res.body).to.be.an('object');
+        expect(res.body.success).to.equal(false);
+        expect(res.body.message).to.equal('No Permission to Access this Resources');
+        done();
+      });
+  });
+
+  it('Should not be able to delete reported article if role is Author', (done) => {
+    chai.request(app)
+      .delete(`/api/v1/admins/articles/${articleSlug}/reports`)
+      .set('x-access-token', authorToken)
+      .send(report)
+      .end((err, res) => {
+        expect(res.status).to.equal(403);
+        expect(res.body).to.be.an('object');
+        expect(res.body.success).to.equal(false);
+        expect(res.body.message).to.equal('No Permission to Access this Resources');
+        done();
+      });
+  });
+
+  it('Should return no article found if Admin trys to delete no-existing article', (done) => {
+    chai.request(app)
+      .delete('/api/v1/admins/articles/node-for-beginners/reports')
+      .set('x-access-token', adminToken)
+      .send(report)
+      .end((err, res) => {
+        expect(res.status).to.equal(404);
+        expect(res.body.message).to.equal('article does not exist');
+        done();
+      });
+  });
+
+  it('Should be able to delete reported article if role is Admin', (done) => {
+    chai.request(app)
+      .delete(`/api/v1/admins/articles/${articleSlug}/reports`)
+      .set('x-access-token', adminToken)
+      .send(report)
+      .end((err, res) => {
+        expect(res.status).to.equal(204);
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
It adds functionality that permits only the admins to delete reported articles

#### Description of Task to be completed?
- create a method that deletes reported articles in articleController
- create and add admin permission to the delete reported articles endpoint
- write a test to test the condition

#### How should this be manually tested?
- create and report an article as a user or author
- It won't allow you to delete the article as a user or author
- as an admin, you will be able to delete the reported article

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
Story type: feature
Story title: An admin should be able to delete reported articles authenticated operation.
Story ID: #161407876

#### Screenshots (if appropriate)
N/A
#### Questions:```
N/A